### PR TITLE
Check if contentType is text/html and filePath has no extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,6 @@ const server = http.createServer((req, res) => {
 
   // Check if contentType is text/html but no .html file extension
   if (contentType == "text/html" && extname == "") filePath += ".html";
-  console.log(filePath);
 
   // log the filePath
   console.log(filePath);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-const http = require('http');
-const path = require('path');
-const fs = require('fs');
+const http = require("http");
+const path = require("path");
+const fs = require("fs");
 
 const server = http.createServer((req, res) => {
   // if (req.url === '/') {
@@ -26,45 +26,48 @@ const server = http.createServer((req, res) => {
   // Build file path
   let filePath = path.join(
     __dirname,
-    'public',
-    req.url === '/' ? 'index.html' : req.url
+    "public",
+    req.url === "/" ? "index.html" : req.url
   );
 
   // Extension of file
   let extname = path.extname(filePath);
 
   // Initial content type
-  let contentType = 'text/html';
+  let contentType = "text/html";
 
   // Check ext and set content type
   switch (extname) {
-    case '.js':
-      contentType = 'text/javascript';
+    case ".js":
+      contentType = "text/javascript";
       break;
-    case '.css':
-      contentType = 'text/css';
+    case ".css":
+      contentType = "text/css";
       break;
-    case '.json':
-      contentType = 'application/json';
+    case ".json":
+      contentType = "application/json";
       break;
-    case '.png':
-      contentType = 'image/png';
+    case ".png":
+      contentType = "image/png";
       break;
-    case '.jpg':
-      contentType = 'image/jpg';
+    case ".jpg":
+      contentType = "image/jpg";
       break;
   }
+
+  // Check if contentType is text/html but no .html file extension
+  if (contentType == "text/html" && extname == "") filePath += ".html";
 
   // Read File
   fs.readFile(filePath, (err, content) => {
     if (err) {
-      if (err.code == 'ENOENT') {
+      if (err.code == "ENOENT") {
         // Page not found
         fs.readFile(
-          path.join(__dirname, 'public', '404.html'),
+          path.join(__dirname, "public", "404.html"),
           (err, content) => {
-            res.writeHead(200, { 'Content-Type': 'text/html' });
-            res.end(content, 'utf8');
+            res.writeHead(200, { "Content-Type": "text/html" });
+            res.end(content, "utf8");
           }
         );
       } else {
@@ -74,8 +77,8 @@ const server = http.createServer((req, res) => {
       }
     } else {
       // Success
-      res.writeHead(200, { 'Content-Type': contentType });
-      res.end(content, 'utf8');
+      res.writeHead(200, { "Content-Type": contentType });
+      res.end(content, "utf8");
     }
   });
 });

--- a/index.js
+++ b/index.js
@@ -58,6 +58,9 @@ const server = http.createServer((req, res) => {
   // Check if contentType is text/html but no .html file extension
   if (contentType == "text/html" && extname == "") filePath += ".html";
 
+  // log the filePath
+  console.log(filePath);
+
   // Read File
   fs.readFile(filePath, (err, content) => {
     if (err) {


### PR DESCRIPTION
My version would err on /about so I cloned your version and it did too. This pr checks to be sure that .html file extension exists if contentType is text/html